### PR TITLE
Better support for different BMC hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Supported Release 0.0.5
+### Summary
+* bmc
+    - change parameter name to manage_oem_repo because it more informativ.
+    - change parameter name and type to oem_software of type Array to better support remote setup.
+
 ## Supported Release 0.0.4
 ### Summary
 Module is now PDK complient 

--- a/README.md
+++ b/README.md
@@ -5,30 +5,20 @@
 [apt module]: https://forge.puppet.com/puppetlabs/apt
 [racadm]: http://pilot.search.dell.com/racadm
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview](#overview)
 2. [Module Description](#module-description)
 3. [Setup](#setup)
-    * [Setup requirements](#setup-requirements)
+    * [Requirements](#Setup-Requirements)
+    * [Installation](#beginning-with-bmc)
 4. [Usage](#usage)
 5. [Operating Systems Support](#operating-systems-support)
 6. [Development](#development)
 
-##Overview
+## Overview
 
 This module configures the Remote Management System (Baseboard Management Controller) on Enterprise servers. 
-
-##Setup
-
-**What this module affects:**
-This module affect's configures the BMC controller.
-
-###Setup Requirements
-* PuppetLabs [stdlib module]
-* PuppetLabs [apt module]
-* Puppet version >= 4.0.x
-* Facter version >= 2.4.3
 
 ##Module Description
 
@@ -36,6 +26,23 @@ You can configure the BMC's LAN, LDAP and SSL certificates and manage the local 
 
 It use [IPMItool] or a server provider specific tool (ie. [racadm]) to do the actual communication with the BMC.
 
+## Setup
+
+**What this module affects:**
+This module affect's configures the BMC controller.
+
+### Setup Requirements
+* PuppetLabs [stdlib module]
+* PuppetLabs [apt module]
+* Puppet version >= 4.0.x
+* Facter version >= 2.4.3
+
+###Beginning with bmc
+To begin using the bmc module just include the bmc module and it will install ipmitools and 3rd party OEM sofware if it
+is run on supported hardware.
+```puppet
+  include bmc
+```
 
 ##Usage
 ###Simple user

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,21 +1,10 @@
-# = Class: bmc
+#Class: bmc
 #
-# This module manages the bmc (Baseboard Management Controller)
-# and the software needed to control it.
+# Parameters:
 #
-# == Parameters:
-#
-# [*ensure*]
-#   Parsed to package and controls the state of the software
-#   Default: present
-#
-# [*manage_repo*]
-#   Should the module manged the repositories
-#   Default: true
-#
-# [*manage_idrac*]
-#   Should idrac software be installed
-#   Default: true if OS is installed on a DELL hardware
+# ensure: Control the existences of this bmc module.
+# manage_oem_repo: Should 3rd party OEM repositry be managed.
+# oem_software: What 3rd party OEM should be installed.
 #
 # Actions:
 #
@@ -25,8 +14,8 @@
 #
 class bmc (
   Enum['present', 'absent', 'purged', 'latest']$ensure = 'present',
-  Boolean $manage_repo                                 = true,
-  Boolean $manage_idrac                                = $bmc::params::manage_idrac,
+  Boolean $manage_oem_repo                             = true,
+  Array[Enum['idrac']] $oem_software                   = $::bmc::params::oem_software,
 ) inherits bmc::params {
 
   if $ensure == 'present' or $ensure == 'latest' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,7 @@
 # Install ipmitools
 class bmc::install() inherits bmc {
 
-  package { $::bmc::params::ipmi_packages:
+  package { $::bmc::ipmi_packages:
     ensure => $::bmc::ensure,
   }
 }

--- a/manifests/oem.pp
+++ b/manifests/oem.pp
@@ -1,5 +1,5 @@
 # @api private
 # Handle the orchestration of oem software
 class bmc::oem() inherits bmc {
-  if $::bmc::manage_idrac { contain 'bmc::oem::idrac' }
+  if member($::bmc::oem_software, 'idrac') { contain 'bmc::oem::idrac' }
 }

--- a/manifests/oem/idrac.pp
+++ b/manifests/oem/idrac.pp
@@ -1,7 +1,7 @@
 # @api private
 # Install idrac software
 class bmc::oem::idrac inherits bmc {
-  if $::bmc::manage_repo {
+  if $::bmc::manage_oem_repo {
     case $::osfamily {
       'Debian': {
         include ::apt
@@ -24,7 +24,7 @@ class bmc::oem::idrac inherits bmc {
       }
       'RedHat': {
         exec { 'Dell Yum repository':
-          command => 'wget -q -O - http://linux.dell.com/repo/hardware/dsu/bootstrap.cgi | bash',
+          command => 'curl -s http://linux.dell.com/repo/hardware/dsu/bootstrap.cgi | bash',
           cwd     => '/tmp',
           creates => '/etc/yum.repos.d/dell-system-update.repo',
           path    => ['/usr/bin', '/usr/sbin'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,8 +4,8 @@ class bmc::params () {
 
   case $::manufactor_id {
     # Dell inc.
-    '674': { $manage_idrac = true }
-    default: { $manage_idrac = false }
+    '674': { $oem_software = ['idrac'] }
+    default: { $oem_software = [] }
   }
 
   case $::osfamily {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "horsefish-bmc",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "horsefish",
   "summary": "Configures and manages Out-of-band management controller.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Changed the parameter type to a array to its not needed to add new parameters when/if more BMC is supported.
Improved documentation.
Changed from wget to curl because wget is not default installed on Rhel/Centos 7.5