### PR TITLE
Primitive support for idrac9 - a better solution whould be to remove …

### DIFF
--- a/lib/puppet/provider/bmc_user/racadm7.rb
+++ b/lib/puppet/provider/bmc_user/racadm7.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:bmc_user).provide(:racadm7) do
       else
         racadm_out = Racadm.racadm_call(
           call_info,
-          ['get', "iDRAC.Users.#{getconfig_user['# cfgUserAdminIndex']}"],
+          ['get', "iDRAC.Users.#{getconfig_user['#cfgUserAdminIndex']}"],
         )
         idrac_user = Racadm.parse_racadm racadm_out
         type.provider = new(

--- a/lib/puppet_x/racadm/racadm.rb
+++ b/lib/puppet_x/racadm/racadm.rb
@@ -36,7 +36,7 @@ class Racadm
           subvalue = '[Key=' + sub_line_array.join('=').strip
           parsed[subkey] = subvalue
         elsif !sub_line_array[0].start_with? '!!'
-          subkey = sub_line_array.slice!(0).strip
+          subkey = sub_line_array.slice!(0).strip.gsub(%r{\s+}, '')
           subvalue = sub_line_array.join('=').strip
           parsed[subkey] = subvalue
         end

--- a/spec/fixtures/bmc/racadm7_getConfigUserRoot.txt
+++ b/spec/fixtures/bmc/racadm7_getConfigUserRoot.txt
@@ -1,0 +1,15 @@
+# cfgUserAdminIndex=2
+cfgUserAdminUserName=root
+# cfgUserAdminPassword=******** (Write-Only)
+cfgUserAdminEnable=1
+cfgUserAdminPrivilege=0x000001ff
+cfgUserAdminIpmiLanPrivilege=4
+cfgUserAdminIpmiSerialPrivilege=4
+cfgUserAdminSolEnable=1
+
+
+RAC1168: The RACADM "getconfig" command will be deprecated in a
+future version of iDRAC firmware. Run the RACADM
+"racadm get" command to retrieve the iDRAC configuration parameters.
+For more information on the get command, run the RACADM command
+"racadm help get".

--- a/spec/fixtures/bmc/racadm9_getConfigUserRoot.txt
+++ b/spec/fixtures/bmc/racadm9_getConfigUserRoot.txt
@@ -1,0 +1,15 @@
+#cfgUserAdminIndex=2
+cfgUserAdminUserName=root
+!!cfgUserAdminPassword=******** (Write-Only)
+cfgUserAdminEnable=Enabled
+cfgUserAdminPrivilege=0x1ff
+cfgUserAdminIpmiLanPrivilege=4
+cfgUserAdminIpmiSerialPrivilege=4
+cfgUserAdminSolEnable=Enabled
+
+
+RAC1168: The RACADM "getconfig" command will be deprecated in a
+future version of iDRAC firmware. Run the RACADM
+"racadm get" command to retrieve the iDRAC configuration parameters.
+For more information on the get command, run the RACADM command
+"racadm help get".

--- a/spec/unit/puppet_x/racadm/racadm_spec.rb
+++ b/spec/unit/puppet_x/racadm/racadm_spec.rb
@@ -13,6 +13,14 @@ describe Racadm do
     output = File.join(File.dirname(__FILE__), '..', '..', '..', 'fixtures', 'bmc', 'racadm7_getConfigUserNotExist.txt')
     IO.read(output)
   end
+  let(:idrac7_getConfigUserRoot) do
+    output = File.join(File.dirname(__FILE__), '..', '..', '..', 'fixtures', 'bmc', 'racadm7_getConfigUserRoot.txt')
+    IO.read(output)
+  end
+  let(:idrac9_getConfigUserRoot) do
+    output = File.join(File.dirname(__FILE__), '..', '..', '..', 'fixtures', 'bmc', 'racadm9_getConfigUserRoot.txt')
+    IO.read(output)
+  end
   let(:getIDRAC_Users) do
     output = File.join(File.dirname(__FILE__), '..', '..', '..', 'fixtures', 'bmc', 'racadm7_getIDRAC.Users.txt')
     IO.read(output)
@@ -62,11 +70,46 @@ describe Racadm do
     end
   end
 
-  describe 'racadm7 get IDRAC.LDAP' do
+  describe 'racadm7 getconfig NoUser' do
     subject { described_class.parse_racadm getConfigUserNotExist }
 
     it do
       is_expected.to be_empty
+    end
+  end
+
+  describe 'idrac7 getconfig Root' do
+    subject { described_class.parse_racadm idrac7_getConfigUserRoot }
+
+    it do
+      is_expected
+        .to include(
+          '#cfgUserAdminIndex' => '2',
+          'cfgUserAdminUserName' => 'root',
+          '#cfgUserAdminPassword' => '******** (Write-Only)',
+          'cfgUserAdminEnable' => '1',
+          'cfgUserAdminPrivilege' => '0x000001ff',
+          'cfgUserAdminIpmiLanPrivilege' => '4',
+          'cfgUserAdminIpmiSerialPrivilege' => '4',
+          'cfgUserAdminSolEnable' => '1',
+        )
+    end
+  end
+
+  describe 'racadm9 getconfig Root' do
+    subject { described_class.parse_racadm idrac9_getConfigUserRoot }
+
+    it do
+      is_expected
+        .to include(
+          '#cfgUserAdminIndex' => '2',
+          'cfgUserAdminUserName' => 'root',
+          'cfgUserAdminEnable' => 'Enabled',
+          'cfgUserAdminPrivilege' => '0x1ff',
+          'cfgUserAdminIpmiLanPrivilege' => '4',
+          'cfgUserAdminIpmiSerialPrivilege' => '4',
+          'cfgUserAdminSolEnable' => 'Enabled',
+        )
     end
   end
 


### PR DESCRIPTION
…all calls to getconfig method because it is deprecated