### PR TITLE
Add support for managing syslog settings on iDRAC

### DIFF
--- a/lib/puppet/provider/bmc_syslog/racadm7.rb
+++ b/lib/puppet/provider/bmc_syslog/racadm7.rb
@@ -1,0 +1,69 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'racadm', 'racadm.rb'))
+require 'tempfile'
+
+Puppet::Type.type(:bmc_syslog).provide(:racadm7) do
+  desc 'Manage syslog configuration via racadm7.'
+
+  confine osfamily: [:redhat, :debian]
+  confine exists: '/opt/dell/srvadmin/bin/idracadm7'
+
+  mk_resource_methods
+
+  def self.prefetch(resources)
+    resources.each do |_key, type|
+      racadm_out = Racadm.racadm_call(
+        {
+          bmc_username: type.value(:bmc_username),
+          bmc_password: type.value(:bmc_password),
+          bmc_server_host: type.value(:bmc_server_host),
+        },
+        ['get', 'iDRAC.SysLog'],
+      )
+      syslog_config = Racadm.parse_racadm racadm_out
+      syslog_servers = []
+      syslog_servers[0] = syslog_config['Server1'] unless syslog_config['Server1'].empty?
+      syslog_servers[1] = syslog_config['Server2'] unless syslog_config['Server2'].empty?
+      syslog_servers[2] = syslog_config['Server3'] unless syslog_config['Server3'].empty?
+
+      type.provider = new(
+        syslog_enable: Racadm.s_to_bool(syslog_config['SysLogEnable']),
+        syslog_servers: syslog_servers,
+        port: syslog_config['Port'],
+      )
+    end
+  end
+
+  def syslog_enable=(value)
+    Racadm.racadm_call(
+      resource,
+      ['set', 'iDRAC.SysLog.SysLogEnable', Racadm.bool_to_s(value)],
+    )
+  end
+
+  def syslog_servers=(value)
+    syslog_servers = Array.new(3, "''")
+    syslog_servers[0] = value[0] if value.size >= 1
+    syslog_servers[1] = value[1] if value.size >= 2
+    syslog_servers[2] = value[2] if value.size >= 3
+
+    Racadm.racadm_call(
+      resource,
+      ['set', 'iDRAC.SysLog.Server1', syslog_servers[0]],
+    )
+    Racadm.racadm_call(
+      resource,
+      ['set', 'iDRAC.SysLog.Server2', syslog_servers[1]],
+    )
+    Racadm.racadm_call(
+      resource,
+      ['set', 'iDRAC.SysLog.Server3', syslog_servers[2]],
+    )
+  end
+
+  def port=(value)
+    Racadm.racadm_call(
+      resource,
+      ['set', 'iDRAC.SysLog.Port', value],
+    )
+  end
+end

--- a/lib/puppet/type/bmc_syslog.rb
+++ b/lib/puppet/type/bmc_syslog.rb
@@ -1,0 +1,36 @@
+require 'resolv'
+require 'pathname'
+
+Puppet::Type.newtype(:bmc_syslog) do
+  @doc = 'A resource type to manage syslog configuration.'
+
+  newparam(:name, namevar: true) do
+    desc 'Identification of the BMC syslog configuration.'
+  end
+
+  newproperty(:syslog_enable) do
+  end
+
+  newproperty(:syslog_servers, array_matching: :all) do
+  end
+
+  newproperty(:port) do
+  end
+
+  newparam(:bmc_username) do
+    desc 'Username used to connect with bmc service.'
+  end
+
+  newparam(:bmc_password) do
+    desc 'Password used to connect with bmc service.'
+  end
+
+  newparam(:bmc_server_host) do
+    desc 'RAC host address. Defaults to ipmitool lan print > IP Address'
+    validate do |value|
+      unless value =~ Resolv::IPv4::Regex || value =~ Resolv::IPv6::Regex
+        raise Puppet::Error, '%s is not a valid ip address' % value
+      end
+    end
+  end
+end


### PR DESCRIPTION
This defines a resource, bmc_syslog which similar to bmc_time and configures iDRAC syslog settings.